### PR TITLE
interactivity improvements

### DIFF
--- a/save-visited-files.el
+++ b/save-visited-files.el
@@ -105,7 +105,8 @@
     (insert-file-contents (or location save-visited-files-location))
     (ignore-errors
       (beginning-of-buffer)
-      (while (not (eq (point-max) (line-end-position)))
+      (dotimes-with-progress-reporter (line (count-lines (point-min) (point-max)))
+          "Restoring previously visited files"
         (find-file-noselect
          (buffer-substring-no-properties (line-beginning-position)
                                          (line-end-position))


### PR DESCRIPTION
I recently learned about with-temp-buffer + insert-file-contents, and also find-file-noselect.  These make restoring much faster (for me anyway).  In particular, before it seemed to be reautoloading modes sometimes(probably due to save-excursion, but I'm not sure), and now it does not.  I also made the save/restore functions more convenient if called interactively; they will default to the normal location, and set the pwd to its directory, so you can keep such files in one place more easily.  Finally, I used a progress-reporter to give some feedback when restoring many files.
