### PR TITLE
use mapcar instead of mapc where there are no side effects

### DIFF
--- a/save-visited-files.el
+++ b/save-visited-files.el
@@ -93,7 +93,7 @@
       (erase-buffer)
       (mapc (lambda (x) (insert x "\n"))
             (cl-remove-if (lambda (x) (or (string-equal location x) (eq nil x)))
-                          (mapc 'buffer-file-name (buffer-list))))))
+                          (mapcar 'buffer-file-name (buffer-list))))))
   nil)
 
 ;;;###autoload


### PR DESCRIPTION
Stopped working for me after a recent update (I'm on Emacs 24.3.1, but I'm not entirely sure when it stopped working).  Here's the fix.  This also fixes a compile warning.
